### PR TITLE
Issue with server hanging up after the first mediator fixed.

### DIFF
--- a/gateway-core/components/org.wso2.carbon.gateway.core/src/main/java/org/wso2/carbon/gateway/core/flow/contentaware/ByteBufferBackedInputStream.java
+++ b/gateway-core/components/org.wso2.carbon.gateway.core/src/main/java/org/wso2/carbon/gateway/core/flow/contentaware/ByteBufferBackedInputStream.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.gateway.core.flow.contentaware;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,8 +31,8 @@ import java.util.concurrent.BlockingQueue;
  */
 
 public class ByteBufferBackedInputStream extends InputStream {
-    ByteBuffer buf;
-    BlockingQueue<ByteBuffer> buffersQueue;
+    private ByteBuffer buf;
+    private BlockingQueue<ByteBuffer> buffersQueue;
     private static final Logger log = LoggerFactory.getLogger(ByteBufferBackedInputStream.class);
 
     public ByteBufferBackedInputStream(ByteBuffer buf) {
@@ -82,6 +81,5 @@ public class ByteBufferBackedInputStream extends InputStream {
         } catch (InterruptedException e) {
             log.error("Error occurred during conversion from CarbonMessage", e);
         }
-
     }
 }

--- a/mediators/jsontoxmltestmediator/components/org.wso2.carbon.gateway.mediators.jsontoxmltestmediator/src/main/java/org/wso2/carbon/gateway/mediators/jsontoxmltestmediator/JSONtoXMLTestMediator.java
+++ b/mediators/jsontoxmltestmediator/components/org.wso2.carbon.gateway.mediators.jsontoxmltestmediator/src/main/java/org/wso2/carbon/gateway/mediators/jsontoxmltestmediator/JSONtoXMLTestMediator.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.gateway.core.flow.AbstractMediator;
 import org.wso2.carbon.gateway.core.flow.contentaware.MIMEType;
 import org.wso2.carbon.messaging.CarbonCallback;
 import org.wso2.carbon.messaging.CarbonMessage;
+import org.wso2.carbon.messaging.DefaultCarbonMessage;
 
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -74,6 +75,12 @@ public class JSONtoXMLTestMediator extends AbstractMediator {
         String msgBody = new String(charBuf.array());
 
         log.info("\n" + msgBody);
+
+        //TODO: Find a better way to consume the body of a carbon message
+
+        if(convertedMsg instanceof DefaultCarbonMessage) {
+            ((DefaultCarbonMessage) convertedMsg).setStringMessageBody(msgBody);
+        }
 
         return next(convertedMsg, carbonCallback);
     }

--- a/mediators/xmltojsontestmediator/components/org.wso2.carbon.gateway.mediators.xmltojsontestmediator/src/main/java/org/wso2/carbon/gateway/mediators/xmltojsontestmediator/XMLtoJSONTestMediator.java
+++ b/mediators/xmltojsontestmediator/components/org.wso2.carbon.gateway.mediators.xmltojsontestmediator/src/main/java/org/wso2/carbon/gateway/mediators/xmltojsontestmediator/XMLtoJSONTestMediator.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.gateway.core.flow.AbstractMediator;
 import org.wso2.carbon.gateway.core.flow.contentaware.MIMEType;
 import org.wso2.carbon.messaging.CarbonCallback;
 import org.wso2.carbon.messaging.CarbonMessage;
+import org.wso2.carbon.messaging.DefaultCarbonMessage;
 
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -61,6 +62,10 @@ public class XMLtoJSONTestMediator extends AbstractMediator {
         String msgBody = new String(charBuf.array());
 
         log.info("\n" + msgBody);
+
+        if(convertedMsg instanceof DefaultCarbonMessage) {
+            ((DefaultCarbonMessage) convertedMsg).setStringMessageBody(msgBody);
+        }
 
         return next(convertedMsg, carbonCallback);
     }


### PR DESCRIPTION
Fixed the issue with a CarbonMessage with an empty body being passed on to the second mediator. Added a more comprehensive CarbonMessage copying functionality in the convertTo() method in ConversionManager.
